### PR TITLE
[RELEASE] Expo Datadog Plugin v51.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-datadog",
-  "version": "51.0.0",
+  "version": "51.0.1",
   "description": "A client-side Expo module to interact with Datadog",
   "main": "build/index.js",
   "scripts": {

--- a/src/plugin/common/config.ts
+++ b/src/plugin/common/config.ts
@@ -1,2 +1,8 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
 export const DEFAULT_DATADOG_GRADLE_PLUGIN_VERSION = "1.14.0";
 export const IOS_DSYMS_BUILD_PHASE_NAME = "Upload dSYMs to Datadog";

--- a/src/plugin/common/exports.ts
+++ b/src/plugin/common/exports.ts
@@ -1,3 +1,9 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
 export const IOS_SOURCEMAP_FILE_EXPORT =
   "export SOURCEMAP_FILE=$DERIVED_FILE_DIR/main.jsbundle.map";
 

--- a/src/plugin/common/utils.ts
+++ b/src/plugin/common/utils.ts
@@ -1,3 +1,9 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
 export const escapeStringForIOSBuildPhase = (str: string) => {
   return str
     .replace(/\\/g, "\\\\") // Escape backslashes


### PR DESCRIPTION
## What's Changed
* [RUM-4060] Fix datadog-ci path resolving on iOS scripts by @marco-saia-datadog in https://github.com/DataDog/expo-datadog/pull/38


**Full Changelog**: https://github.com/DataDog/expo-datadog/compare/51.0.0...51.0.1

[RUM-4060]: https://datadoghq.atlassian.net/browse/RUM-4060?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ