### PR TITLE
fix(ios): Add input/output paths to dSYM upload build phase

### DIFF
--- a/src/plugin/withIosDsyms/withIosDsyms.ts
+++ b/src/plugin/withIosDsyms/withIosDsyms.ts
@@ -44,6 +44,12 @@ ${IOS_DATADOG_CI_EXPORT}
 $DATADOG_CI_EXEC dsyms upload $DWARF_DSYM_FOLDER_PATH
         `,
         shellPath: "/bin/sh",
+        inputPaths: [
+          '"$(DWARF_DSYM_FOLDER_PATH)/$(DWARF_DSYM_FILE_NAME)"',
+          '"$(DWARF_DSYM_FOLDER_PATH)/$(DWARF_DSYM_FILE_NAME)/Contents/Resources/DWARF/$(PRODUCT_NAME)"',
+          '"$(DWARF_DSYM_FOLDER_PATH)/$(DWARF_DSYM_FILE_NAME)/Contents/Info.plist"',
+        ],
+        outputPaths: ['"$(DERIVED_FILE_DIR)/datadog-dsym-upload-marker"'],
       }
     );
 


### PR DESCRIPTION
## Summary

Adds `inputPaths` and `outputPaths` to the "Upload dSYMs to Datadog" build phase to ensure correct execution order during Xcode builds.

## Problem

Without input/output file dependencies, Xcode cannot determine when to run the build phase. This causes:

1. **Upload script runs before dSYM files are generated** - The build phase executes before dSYM generation completes
2. **dSYMs are not uploaded to Datadog** - Crash reports remain unsymbolicated
3. **Xcode warning** - "Script has ambiguous dependencies causing it to run on every build"

**Evidence from EAS build logs:**
```
› Executing XXApp » Upload dSYMs to Datadog    ← Upload runs FIRST
› Generating debug XXApp » XXApp.app.dSYM  ← dSYM generated AFTER
```

## Solution

Specify the dSYM files as `inputPaths` so Xcode waits for their generation before executing the upload script. An `outputPaths` marker file is also added to satisfy Xcode's dependency analysis.

## Testing

- Tested with Expo SDK 53 and expo-datadog 53.0.0
- After applying this fix, the build phase runs after dSYM generation
- dSYM files are successfully uploaded to Datadog
- Crash reports are properly symbolicated